### PR TITLE
Adjust CSS to make ZIMply usable with MWoffliner dumps

### DIFF
--- a/zimply/template.html
+++ b/zimply/template.html
@@ -24,6 +24,7 @@
       background-color: rgba(255,255,255,0.96);
       font-family: Verdana, sans-serif;
       font-size: 90%;
+      min-height: auto;
     }
     .search {
       font-size: 100%;


### PR DESCRIPTION
MWoffliner CSS causes a clash, resulting in 100% min-height for the
navbar (that is, navbar covers entire page).

Add a

min-height: auto;

To .navbar selector, to override 100% size.

Signed-off-by: Vitaly Ostrosablin <tmp6154@yandex.ru>