### PR TITLE
Fix articles with index == 0 not loading

### DIFF
--- a/zimply/zim_core.py
+++ b/zimply/zim_core.py
@@ -673,8 +673,9 @@ class ZIMFile:
 
     def get_article_by_url(self, namespace, url, follow_redirect=True):
         entry, idx = self._get_entry_by_url(namespace, url)  # get the entry
-        if idx:  # we found an index and return the article at that index
-            return self._get_article_by_index(idx, follow_redirect=follow_redirect)
+        if idx is None:
+            return None
+        return self._get_article_by_index(idx, follow_redirect=follow_redirect)
 
     def get_article_by_id(self, idx, follow_redirect=True):
         return self._get_article_by_index(idx, follow_redirect=follow_redirect)


### PR DESCRIPTION
I noticed an issue where `get_article_by_url` would return `None` in the rare situation that an article's index is `0`, such as in a tiny zim file with only one article.